### PR TITLE
[FIX] sign_oca: Fixed two issues in signature module: * 1. dialog service lazy initialization * 2. zindex issue

### DIFF
--- a/sign_oca/static/src/components/sign_oca_pdf_portal/sign_oca_pdf_portal.esm.js
+++ b/sign_oca/static/src/components/sign_oca_pdf_portal/sign_oca_pdf_portal.esm.js
@@ -8,6 +8,7 @@ import env from "web.public_env";
 import {renderToString} from "@web/core/utils/render";
 import session from "web.session";
 import {templates} from "@web/core/assets";
+
 export class SignOcaPdfPortal extends SignOcaPdf {
     setup() {
         super.setup(...arguments);
@@ -79,11 +80,20 @@ export function initDocumentToSign(properties) {
         ]).then(async function () {
             var app = new App(null, {templates, test: true});
             renderToString.app = app;
-            mount(SignOcaPdfPortal, document.body, {
-                env,
-                props: properties,
-                templates: templates,
-            });
+
+            let dialogService = env.services.dialog;
+            const dialogServiceInterval = setInterval(() => {
+                if (dialogService) {
+                    clearInterval(dialogServiceInterval);
+                    mount(SignOcaPdfPortal, document.body, {
+                        env,
+                        props: properties,
+                        templates: templates,
+                    });
+                } else {
+                    dialogService = env.services.dialog;
+                }
+            }, 100);
         });
     });
 }

--- a/sign_oca/static/src/scss/sign.scss
+++ b/sign_oca/static/src/scss/sign.scss
@@ -16,6 +16,8 @@
         border: transparent;
         background-color: transparent;
     }
+
+    z-index: 2147483647; // highest possible css zindex to ensure that the field is never overlapped
 }
 .o_sign_oca_field_config {
     position: absolute;


### PR DESCRIPTION
# 🔍 Problem Statement

1. Race Condition in dialog Service Initialization

- The dialog service is sometimes unavailable when SignOcaPdfPortal is initialized, leading to an error on the first page load.
- After a manual reload, the issue disappears, indicating that the service is registered asynchronously after the component tries to access it.

2. Z-Index Issue in Signature Dialog

- The signature dialog sometimes appears behind other UI elements, making it inaccessible.
- This is due to an incorrect or missing z-index value for the modal container in the CSS styles.

# 🛠 Solution
✅ Fix for Race Condition in dialog Service
- Implement a polling mechanism (setInterval) to check for the availability of env.services.dialog.
- The component will only mount after the service is available, preventing undefined errors.
- Once dialog is available, the polling stops (clearInterval).

✅ Fix for Z-Index Issue
- Ensure the signature dialog always appears on top by applying the correct z-index.

# 📅 Acceptance Criteria
- The dialog service is always available before SignOcaPdfPortal is mounted.
- No undefined errors related to env.services.dialog occur.
- The page loads correctly without requiring a manual reload.
- The signature dialog is always visible and interactive, with a proper z-index.